### PR TITLE
Animate Me Responder

### DIFF
--- a/lib/bruce_hedwig/echo_responder.ex
+++ b/lib/bruce_hedwig/echo_responder.ex
@@ -4,7 +4,7 @@ defmodule BruceHedwig.EchoResponder do
   @usage """
   ping - Responds to a user who says ping with a pong
   """
-  respond ~r/ping/i, msg do
+  respond ~r/ping$/i, %{robot: robot} = msg do
     reply msg, "pong"
   end
 end

--- a/lib/bruce_hedwig/image_responder.ex
+++ b/lib/bruce_hedwig/image_responder.ex
@@ -3,15 +3,24 @@ defmodule BruceHedwig.ImageResponder do
   require Logger
 
   @usage """
-  Image me - Returns a image from a custom google search
+  Image me - Returns an image from a custom google search
   """
-  hear ~r/image me (?<query>.+)/i, msg do
+  respond ~r/image (me )?(?<query>.+)/i, msg do
     query = msg.matches["query"]
-    response = execute_query(query)
+    response = execute_query(query, "")
     reply msg, response
   end
 
-  def execute_query(query) do
+  @usage """
+  Animate me - Returns a gif from a custom google search
+  """
+  respond ~r/animate (me )?(?<query>.+)/i, msg do
+    query = msg.matches["query"]
+    response = execute_query(query, "gif")
+    reply msg, response
+  end
+
+  def execute_query(query, fileType) do
     cse_id = Application.get_env(:bruce_hedwig, :cse_id)
     google_api_key = Application.get_env(:bruce_hedwig, :google_api_key)
     base_url = "https://www.googleapis.com/customsearch/v1"
@@ -22,7 +31,9 @@ defmodule BruceHedwig.ImageResponder do
       safe: "high",
       cx: cse_id,
       key: google_api_key,
+      fileType: fileType,
     }
+
     case HTTPoison.get(base_url, [], params: query_payload) do
       {:ok, %HTTPoison.Response{status_code: 403, body: body}} ->
         "Image quota exceeded :("

--- a/test/echo_test.exs
+++ b/test/echo_test.exs
@@ -1,0 +1,12 @@
+defmodule BruceHedwig.EchoTest do
+  use Hedwig.RobotCase
+
+  alias Hedwig.Responder
+
+  test "response_pattern" do
+    robot = %Hedwig.Robot{name: "bruce", aka: nil}
+
+    assert Responder.respond_pattern(~r/ping/i, robot) ==
+      ~r/^\s*[@]?bruce[:,]?\s*(?:ping)/i
+  end
+end


### PR DESCRIPTION
Adds an "animate me" responder that will filter the Google CSE image search by "gif" file types.

Also uses `respond` over `hear` and adds an end character `$` to the ping responder regex.
